### PR TITLE
Updates to Oa4mp Client UI (PMO-1116)

### DIFF
--- a/Lib/lang.php
+++ b/Lib/lang.php
@@ -68,7 +68,7 @@ $cm_oa4mp_client_texts['en_US'] = array(
   'pl.oa4mp_client_co_admin_client.save.dialog.understand' => 'I understand',
 
   'pl.oa4mp_client_co_admin_client.er.client_exists' => 'A CO may only have one Oa4mp Admin Client',
-  'pl.oa4mp_client_co_admin_client.er.create_error' => 'Unable to create new OIDC client',
+  'pl.oa4mp_client_co_admin_client.er.create_error' => 'OAuth2 server is unwilling to create new OIDC client. Please check your settings.',
   'pl.oa4mp_client_co_admin_client.er.delete_error' => 'Unable to delete OIDC client',
   'pl.oa4mp_client_co_admin_client.er.edit_error' => 'Unable to edit OIDC client',
 

--- a/View/Oa4mpClientCoOidcClients/fields.inc
+++ b/View/Oa4mpClientCoOidcClients/fields.inc
@@ -614,11 +614,8 @@ function js_local_onload() {
           $args['value'] = $c['id'];
           $args['checked'] = false;
 
-          $label = '<div class="named-config-tooltip">';
+          $label = '<div class="named-config">';
           $label = $label . '<span class="named-config-name">' . $c['config_name'] . '</span>';
-          $label = $label . '<span class="named-config-tooltiptext">';
-          $label = $label . $c['description'];
-          $label = $label . '</span>';
           $label = $label . '<span class="named-config-required-scopes">';
           $label = $label . ' requires scope(s) ';
 
@@ -630,7 +627,10 @@ function js_local_onload() {
           $label = $label . implode(', ', $scopes);
           $label = $label . '</span>';
           $label = $label . '</div>';
-
+          $label = $label . '<div class="named-config-desc">';
+          $label = $label . $c['description'];
+          $label = $label . '</div>';
+  
           $args['label'] = $label;
           if(!empty($this->request->data['Oa4mpClientCoOidcClient']['named_config_id'])) {
             if($this->request->data['Oa4mpClientCoOidcClient']['named_config_id'] == $c['id']) {

--- a/View/Oa4mpClientCoOidcClients/fields.inc
+++ b/View/Oa4mpClientCoOidcClients/fields.inc
@@ -709,7 +709,8 @@ function js_local_onload() {
     </div>
     <ul class="field-children" id="oa4mp_client_co_scope">
       <li>
-        <div class="field-info form-check">
+        <div class="field-info form-check checkbox-checked-appear-disabled">
+            <span class="material-icons-outlined">check_box</span>
             <?php
               $args = array();
               $args['type'] = 'checkbox';

--- a/webroot/css/oa4mpclient.css
+++ b/webroot/css/oa4mpclient.css
@@ -57,37 +57,12 @@ div.field-children-inline button {
     margin-top: 4px;
 }
 
-.named-config-tooltip {
-    position: relative;
-    display: inline-block;
-    width: 900px;
-}
-
-.named-config-tooltip .named-config-tooltiptext {
-  visibility: hidden;
-  width: 360px;
-  background-color: rgb(223,239,252);
-  color: #06c;
-  text-align: left;
-  padding-top: 5px;
-  padding-right: 5px;
-  padding-bottom: 5px;
-  padding-left: 8px;
-  border-radius: 6px;
- 
-  /* Position the tooltip text - see examples below! */
-  position: absolute;
-  z-index: 1;
-}
-
-.named-config-tooltip:hover .named-config-tooltiptext {
-  visibility: visible;
-}
-
 .named-config-name {
   font-weight: bold;
 }
-
+.named-config-desc {
+  font-size: 0.9em;
+}
 .named-config-required-scopes {
   font-style: italic;
   font-size: 0.9em;

--- a/webroot/css/oa4mpclient.css
+++ b/webroot/css/oa4mpclient.css
@@ -92,3 +92,20 @@ div.field-children-inline button {
   font-style: italic;
   font-size: 0.9em;
 }
+
+.checkbox-checked-appear-disabled .form-check-input {
+  appearance: none;
+  cursor: default;
+}
+.checkbox-checked-appear-disabled label {
+  cursor: default;
+  color: #666;
+}
+.checkbox-checked-appear-disabled .material-icons-outlined {
+  padding: 0;
+  margin: 0 0 0 -1.25em;
+  font-size: 16px;
+  vertical-align: middle;
+  color: #666;
+  cursor: default;
+}


### PR DESCRIPTION
This PR handles three simple updates:

1. Make openid checkbox "appear" disabled.
2. Place named config description on the page (rather than expose it as a tooltip)
3. Update the client creation error messages.